### PR TITLE
Update image URLs in admin dashboard and payment sidebar to use HTTPS

### DIFF
--- a/resources/views/dashboard/admin-dashboard/index.blade.php
+++ b/resources/views/dashboard/admin-dashboard/index.blade.php
@@ -8,7 +8,7 @@
                     <p class="pb-4">Fokuslah untuk mencapai tujuanmu, meskipun banyak hal yang menarik dalam perjalanannya. 🚀</p>
                     <a href="{{ route('student.index') }}" class="btn btn-sm btn-primary waves-effect waves-light">Lihat Data Siswa</a>
                 </div>
-                <img src="{{ url('https://hadziqmtqn.github.io/materialize/assets/img/illustrations/trophy.png') }}" class="position-absolute bottom-0 end-0 me-3" height="140" alt="view sales">
+                <img src="{{ url('https://hadziqmtqn.github.io/materialize/assets/img/illustrations/trophy.png') }}" class="position-absolute bottom-0 end-0 me-3" style="height: 140px" alt="view sales">
             </div>
         </div>
         {{--TODO Base Data--}}

--- a/resources/views/dashboard/application/sidebar.blade.php
+++ b/resources/views/dashboard/application/sidebar.blade.php
@@ -15,7 +15,7 @@
     </ul>
     <div class="d-none d-md-block">
         <div class="mt-5 text-center">
-            <img src="{{ asset('materialize/assets/img/illustrations/faq-illustration.png') }}" class="img-fluid w-px-120" alt="FAQ Image" />
+            <img src="{{ url('https://hadziqmtqn.github.io/materialize/assets/img/illustrations/faq-illustration.png') }}" class="img-fluid w-px-120" alt="FAQ Image" />
         </div>
     </div>
 </div>

--- a/resources/views/dashboard/payment/sidebar.blade.php
+++ b/resources/views/dashboard/payment/sidebar.blade.php
@@ -21,7 +21,7 @@
     </ul>
     <div class="d-none d-md-block">
         <div class="mt-5 text-center">
-            <img src="{{ asset('materialize/assets/img/illustrations/faq-illustration.png') }}" class="img-fluid w-px-120" alt="FAQ Image" />
+            <img src="{{ url('https://hadziqmtqn.github.io/materialize/assets/img/illustrations/faq-illustration.png') }}" class="img-fluid w-px-120" alt="FAQ Image" />
         </div>
     </div>
 </div>


### PR DESCRIPTION
This pull request includes updates to image URLs in several Blade template files to use absolute URLs instead of relative asset paths.

Changes to image URLs:

* [`resources/views/dashboard/admin-dashboard/index.blade.php`](diffhunk://#diff-0493fbad52cc4efa53d4b90bb766f4a965d5ddc10e7c1c709074a2f4cff6b08aL11-R11): Updated the image URL for the trophy illustration and added inline style for height.
* [`resources/views/dashboard/application/sidebar.blade.php`](diffhunk://#diff-93a6e26791e6c5dccbae7df26b6d7e9d3f1570cf2fa54ea25e89ce483adbf59aL18-R18): Changed the image URL for the FAQ illustration to an absolute URL.
* [`resources/views/dashboard/payment/sidebar.blade.php`](diffhunk://#diff-c65b03f1c2d6d9522ba1230ac7663eb6b9fc8b43ba30d33e670a826fcfa3e7c4L24-R24): Changed the image URL for the FAQ illustration to an absolute URL.